### PR TITLE
Dokumentation mit MkDocs und Javadoc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,3 +133,9 @@ gradle-app.setting
 .classpath
 .project
 .vscode/settings.json
+
+# MkDocs
+/site/
+/docs/CHANGELOG.md
+/docs/index.md
+/docs/java/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,3 @@
+# Change Log
+
+> TODO: anhand von Commits automatisieren

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ pre-installed on your local dev computer.
 
 * Git clone this repository
 * cd into the directory where you cloned this repo to
+* [Python 3 to generate the project documentation](#documentation)
 
 ## Build and Run
 
@@ -70,6 +71,18 @@ Start a stopped container: `docker start <container id/name>`
 Access the application: [http://localhost:80/cwgenJsf](http://localhost:80/cwgenJsf)
 
 > **_NOTE:_**  The context root string `cwgenJsf` is in the file `build.gradle` specified. By every build, the Gradle plugin _liberty-gradle-plugin_ will generate a `bootstrap.properties` file, which has a property `app.context.root=cwgenJsf`. The generated `bootstrap.properties` can be found in the path `./build/wlp/usr/servers/defaultServer/bootstrap.properties`.
+
+## Documentation
+
+To generate the documentation you need Python 3 and the pip packages
+[`mkdocs`](https://www.mkdocs.org/) and [`mkdocs-material`](https://squidfunk.github.io/mkdocs-material/)
+installed as a prerequisite.
+
+```
+pip install mkdocs mkdocs-material
+```
+
+From there on you can run `gradlew docs` to generate the latest documentation in the `site` directory.
 
 
 ## Special Thanks and Further Reading

--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,5 @@
+import org.gradle.internal.os.OperatingSystem
+
 buildscript {
     repositories {
         mavenCentral()
@@ -164,3 +166,38 @@ git add -u . # only add those already being tracked
 }
 
 assemble.dependsOn 'installGitHook'
+
+// Docs
+
+tasks.withType(Javadoc) {
+    destinationDir = new File("${projectDir}/docs/java/")
+    options {
+        noQualifiers 'java.lang', 'java.util', 'java.io'
+    }
+}
+
+task docs(type: Exec) {
+    doFirst {
+        copy {
+            println "Copying '${projectDir}/README.md' to '${projectDir}/docs/index.md'"
+            from "${projectDir}/README.md"
+            into "${projectDir}/docs"
+            rename { "index.md" }
+        }
+        copy {
+            println "Copying '${projectDir}/CHANGELOG.md' to '${projectDir}/docs/CHANGELOG.md'"
+            from "${projectDir}/CHANGELOG.md"
+            into "${projectDir}/docs"
+            rename { "CHANGELOG.md" }
+        }
+    }
+
+    if (OperatingSystem.current().isWindows()) {
+        commandLine 'cmd', '/c', 'mkdocs build'
+    } else {
+        commandLine 'mkdocs build'
+    }
+}
+
+docs.dependsOn javadoc
+docs.group = 'documentation'

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,3 @@
+# Architektur
+
+Hier könnte die Architektur der Anwendung beschrieben werden ...

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,38 @@
+site_name: crossword-gen-jsf
+site_url: https://nnworkspace.github.com/crossword-gen-jsf/
+repo_name: crossword-gen-jsf
+repo_url: https://github.com/nnworkspace/crossword-gen-jsf
+site_description: "An application which generates a word search puzzle"
+site_author: nnworkspace
+remote_branch: gh-pages
+
+copyright: 'Copyright &copy; 2020 nnworkspace'
+
+markdown_extensions:
+  - smarty
+  - codehilite
+  - footnotes
+  - meta
+  - toc:
+      permalink: true
+  - pymdownx.betterem:
+      smart_enable: all
+  - pymdownx.caret
+  - pymdownx.inlinehilite
+  - pymdownx.magiclink
+  - pymdownx.smartsymbols
+  - pymdownx.superfences
+  - pymdownx.tilde
+  - tables
+
+nav:
+  - Home: index.md
+  - Architektur: architecture.md
+  - 'Javadoc ⏏': java/index.html
+  - 'Change Log': CHANGELOG.md
+
+theme:
+  name: 'material'
+  palette:
+    primary: 'blue'
+    accent: 'white'


### PR DESCRIPTION
Ergänzt ein Gradle-Task `gradlew docs` um Dokumentation zu generieren.

Der Task nutzt [MkDocs](https://www.mkdocs.org/), um die zusätzliche Dokumentation mit Markdown-Files zu realisieren. Der Nachteil ist, dass man erstmal Python installieren muss. Dann kann man aber immer MkDocs für alle Projekte nutzen.

Die Javadocs wird mit dem [Standard-Generator](https://github.com/nnworkspace/crossword-gen-jsf/compare/master...JanMalch:master#diff-c197962302397baf3a4cc36463dce5eaR202) generiert. Mit [dokka](https://github.com/Kotlin/dokka) könnte die Dokumentation auch in Markdown generiert werden. Das entspräche auch dem Setup von [OkHttp](https://square.github.io/okhttp/). Allerdings habe ich dokka (noch?) nicht in einem Java-only-Projekt aufgesetzt bekommen. dokka hätte dann auch noch mehr Features wie bspw. Code-Samples.